### PR TITLE
adding the ability to update cluster autoscaler settings

### DIFF
--- a/tools/aks.py
+++ b/tools/aks.py
@@ -867,6 +867,7 @@ def init_aks_tools(mcp: FastMCP):
         enable_node_public_ip: bool = None,
         labels: str = None,
         tags: str = None,
+        disable_cluster_autoscaler: bool = None,
     ) -> str:
         """Update a node pool with new properties.
 
@@ -878,6 +879,7 @@ def init_aks_tools(mcp: FastMCP):
             enable_node_public_ip: Enable/disable nodes having public IPs (optional)
             labels: Comma-separated labels to apply to nodes (optional)
             tags: Space-separated tags in 'key[=value]' format for the node pool (optional)
+            disable_cluster_autoscaler: Disable cluster autoscaler for this node pool (optional)
         """
         try:
             cmd = [
@@ -906,6 +908,9 @@ def init_aks_tools(mcp: FastMCP):
 
             if tags:
                 cmd.extend(["--tags", tags])
+                
+            if disable_cluster_autoscaler:
+                cmd.extend(["--disable-cluster-autoscaler"])
 
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
             return f"Node pool '{nodepool_name}' updated successfully."


### PR DESCRIPTION
This pull request includes several updates to the `tools/aks.py` file to enhance the functionality of the `update_aks_cluster` and `aks_nodepool_update` functions. The key changes involve setting environment variables, adding new parameters for node pool updates, and ensuring non-interactive command execution.

Enhancements to `update_aks_cluster` function:

* Added environment variable `AZURE_CORE_NO_PROMPT` to disable interactive prompts.
* Included the `--yes` flag to avoid waiting for operation completion.
* Passed the environment variable to the `subprocess.run` command.

Enhancements to `aks_nodepool_update` function:

* Added parameters to enable/disable cluster autoscaler and set minimum and maximum node counts. [[1]](diffhunk://#diff-4a2af0722e576c056e588273b227ca404adebf7be24a0408776b78369a51d746R877-R880) [[2]](diffhunk://#diff-4a2af0722e576c056e588273b227ca404adebf7be24a0408776b78369a51d746R892-R895)
* Included the `--yes` flag for non-interactive updates.
* Added logic to handle autoscaler parameters and validate required inputs.